### PR TITLE
get units by external API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem 'bootstrap', '~> 4.3.1'
 gem 'jquery-rails'
 
 gem 'devise'
+gem 'faraday'
+gem 'faraday_middleware'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -51,8 +53,8 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 3.8'
 end
-
 group :development do
+
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
@@ -63,6 +65,7 @@ end
 
 group :test do
   gem 'simplecov', require: false
+  gem 'webmock'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,8 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     devise (4.7.0)
       bcrypt (~> 3.0)
@@ -89,9 +91,14 @@ GEM
     factory_bot_rails (5.0.2)
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.13.1)
+      faraday (>= 0.7.4, < 1.0)
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashdiff (1.0.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.9.1)
@@ -121,6 +128,7 @@ GEM
       libv8 (>= 6.9.411)
     minitest (5.11.3)
     msgpack (1.3.1)
+    multipart-post (2.1.1)
     nio4r (2.5.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
@@ -181,6 +189,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
     ruby_dep (1.5.0)
+    safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -234,6 +243,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.7.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -251,6 +264,8 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   factory_bot_rails
+  faraday
+  faraday_middleware
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
@@ -267,6 +282,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webmock
 
 RUBY VERSION
    ruby 2.6.4p104

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,5 +3,7 @@ class HomeController < ApplicationController
     if account_signed_in?
       return redirect_to new_profile_path unless current_account.profile?     
     end
+
+    @gyms = Gym.all
   end
 end

--- a/app/models/gym.rb
+++ b/app/models/gym.rb
@@ -1,0 +1,19 @@
+class Gym
+  attr_reader :name, :open_hour, :close_hour,
+              :working_days, :address, :images
+
+  def initialize(**args)
+    args.each do |key, value|
+      instance_variable_set("@#{key.to_s}", value)
+    end
+  end
+
+  def self.all
+    response = EspertoAcademy.client.get do |req|
+      req.url 'gyms'
+    end
+    return response.body.map { |gym| new(gym) } if response.status == 200
+
+    []
+  end
+end

--- a/app/services/esperto_academy.rb
+++ b/app/services/esperto_academy.rb
@@ -1,0 +1,35 @@
+require 'faraday'
+require 'faraday_middleware'
+
+class EspertoAcademy
+  class << self 
+    def endpoint 
+      Rails.configuration.esperto_academy[:base_url]
+    end
+
+    def api_version
+      'v1'
+    end
+
+    def esperto_academy_url 
+      "#{endpoint}/api/#{api_version}"
+    end
+
+    def client 
+      @client ||= new_connection
+    end
+
+    private
+
+    def new_connection
+      Faraday.new(url: esperto_academy_url) do |faraday| 
+        faraday.use :instrumentation
+        faraday.headers['Content-Type'] = 'application/json'
+
+        faraday.response :json, parser_options: { symbolize_names: true },
+          content_type: /\bjson$/
+        faraday.adapter :net_http
+      end
+    end
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,1 +1,5 @@
+<h2>Unidades</h2>
 
+<% @gyms.each do |gym| %>
+  <h3 class="gym"><%= gym.name %></h3>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,7 @@ module EspertoFitPersonal
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.esperto_academy = config_for(:esperto_academy).symbolize_keys 
   end
 end

--- a/config/esperto_academy.yml
+++ b/config/esperto_academy.yml
@@ -1,0 +1,6 @@
+development:
+  base_url: http://0.0.0.0:3000
+production:
+  base_url: https://example.com.br/
+test:
+  base_url: http://0.0.0.0:3000

--- a/spec/features/add_unit_to_customer_spec.rb
+++ b/spec/features/add_unit_to_customer_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 feature 'Add unit to customer' do
+  before(:each) do
+    filename = 'gyms.json'
+    url      = 'http://0.0.0.0:3000/api/v1/gyms'
+    stub_get_json(url, filename)
+  end
+  
   scenario 'successfully' do
     #arrange
     unit = create(:unit, name: 'Paulista')

--- a/spec/features/customer_register_account_spec.rb
+++ b/spec/features/customer_register_account_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
-feature 'User register account' do 
+feature 'User register account' do
+  before(:each) do
+    filename = 'gyms.json'
+    url      = 'http://0.0.0.0:3000/api/v1/gyms'
+    stub_get_json(url, filename)
+  end
+  
   scenario 'successfully as customer' do
 
     #act

--- a/spec/features/customer_user_can_register_spec.rb
+++ b/spec/features/customer_user_can_register_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 feature 'Customer can register into system' do
+  before(:each) do
+    filename = 'gyms.json'
+    url      = 'http://0.0.0.0:3000/api/v1/gyms'
+    stub_get_json(url, filename)
+  end
+  
   scenario 'first: basic register' do
     #Arrange
 

--- a/spec/features/personal_authenticates_to_create_schedule_spec.rb
+++ b/spec/features/personal_authenticates_to_create_schedule_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 feature 'Personal authenticates to create schedule' do
+  before(:each) do
+    filename = 'gyms.json'
+    url      = 'http://0.0.0.0:3000/api/v1/gyms'
+    stub_get_json(url, filename)
+  end
+  
   scenario 'successfully' do
     account = create(:personal, email: 'teste@email.com', password: '123456')
     profile = create(:profile, account: account)

--- a/spec/features/personal_creates_schedule_spec.rb
+++ b/spec/features/personal_creates_schedule_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 feature 'Personal creates schedule' do
+  before(:each) do
+    filename = 'gyms.json'
+    url      = 'http://0.0.0.0:3000/api/v1/gyms'
+    stub_get_json(url, filename)
+  end
+  
   scenario 'and they should be logged in' do
     account = create(:personal, email: 'teste@email.com', password: '123456')
     profile = create(:profile, account: account)

--- a/spec/features/personal_user_can_register_spec.rb
+++ b/spec/features/personal_user_can_register_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 feature 'Personal can register into system' do
+  before(:each) do
+    filename = 'gyms.json'
+    url      = 'http://0.0.0.0:3000/api/v1/gyms'
+    stub_get_json(url, filename)
+  end
   scenario 'first: basic register' do
     #Arrange
 

--- a/spec/features/schedule_receives_account_id_spec.rb
+++ b/spec/features/schedule_receives_account_id_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 feature 'Schedule receives account ID' do
+  before(:each) do
+    filename = 'gyms.json'
+    url      = 'http://0.0.0.0:3000/api/v1/gyms'
+    stub_get_json(url, filename)
+  end
+
   scenario 'successfully' do
     personal = create(:personal, email: 'teste@email.com', password: '123456')
     unit = create(:unit, name: 'Matriz')

--- a/spec/features/user_profile_can_be_edited_spec.rb
+++ b/spec/features/user_profile_can_be_edited_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 feature 'User profile can be edited' do
+  before(:each) do
+    filename = 'gyms.json'
+    url      = 'http://0.0.0.0:3000/api/v1/gyms'
+    stub_get_json(url, filename)
+  end
+
   scenario '1: access  account profile details' do
     #Arrange
     profile = create(:profile, :personal)

--- a/spec/features/visitor_view_available_units_spec.rb
+++ b/spec/features/visitor_view_available_units_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+feature 'visitor view units' do
+  before(:each) do
+    filename = 'gyms.json'
+    url      = 'http://0.0.0.0:3000/api/v1/gyms'
+    stub_get_json(url, filename)
+  end
+
+  scenario 'sucessfully' do  
+    visit root_path
+
+    #expect(page).to have_text 'Unidade'
+
+    expect(page).to have_css('.gym', count: 3)
+
+    expect(page).to have_css('h3', text: 'Academia 01')
+    expect(page).to have_css('h3', text: 'Academia 02')
+    expect(page).to have_css('h3', text: 'Academia 03')
+  end
+end

--- a/spec/models/gym_spec.rb
+++ b/spec/models/gym_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe Gym do
+  it 'exists' do
+    attributes = {}
+    gym = Gym.new(attributes)
+
+    expect(gym).to be_a Gym
+  end
+
+  it 'had attributes' do
+    attributes = {  
+      name: 'Academia 1',
+      open_hour: '09:00',
+      close_hour: '22:00',
+      working_days: 'segunda á sexta',
+      address: "Av Paulista 111",
+      images: "https://example.com/image"
+    }
+
+    gym = Gym.new(attributes)
+  
+    expect(gym.name).to eq 'Academia 1'
+    expect(gym.open_hour).to eq '09:00'
+    expect(gym.close_hour).to eq '22:00'
+    expect(gym.working_days).to eq 'segunda á sexta'
+    expect(gym.address).to eq 'Av Paulista 111'
+    expect(gym.images).to eq 'https://example.com/image'
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,13 @@ SimpleCov.start 'rails' do
   add_filter 'app/helpers'
 end
 
+def stub_get_json(url, filename)
+  json_response = JSON.parse(
+    File.read(Rails.root.join('spec', 'support', "#{filename}")
+  ), symbolize_names: true)
+  stub_request(:get, url).
+    to_return(status: 200, body: json_response)
+end
 
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'

--- a/spec/services/esperto_academy_spec.rb
+++ b/spec/services/esperto_academy_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe EspertoAcademy do
+  it 'exists' do
+    esperto_academy = EspertoAcademy.new
+
+    expect(esperto_academy).to be_a EspertoAcademy
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@
 # the additional setup, and require it from the spec files that actually need
 # it.
 #
+require 'webmock/rspec'
 require 'capybara/rspec'
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|

--- a/spec/support/gyms.json
+++ b/spec/support/gyms.json
@@ -1,0 +1,45 @@
+[
+  {
+    "id":1,
+    "created_at":"2019-09-12T17:13:13.272Z",
+    "updated_at":"2019-09-12T17:13:13.275Z",
+    "name":"Academia 01",
+    "cod":1,
+    "open_hour":"09:00",
+    "close_hour":"22:00",
+    "working_days":"segunda à sexta",
+    "address":"Av Paulista 111",
+    "images":["https://lorempixel.com/400/400/sports/", 
+              "https://lorempixel.com/400/400/sports/"
+    ]
+  },
+
+  {
+    "id":2,
+    "created_at":"2019-09-12T17:13:13.272Z",
+    "updated_at":"2019-09-12T17:13:13.275Z",
+    "name":"Academia 02",
+    "cod":2,
+    "open_hour":"09:00",
+    "close_hour":"22:00",
+    "working_days":"segunda à sexta",
+    "address":"Av Maria 333",
+    "images":["https://lorempixel.com/400/400/sports/", 
+              "https://lorempixel.com/400/400/sports/"
+    ]
+  },
+  {
+    "id":3,
+    "created_at":"2019-09-12T17:13:13.272Z",
+    "updated_at":"2019-09-12T17:13:13.275Z",
+    "name":"Academia 03",
+    "cod":3,
+    "open_hour":"09:00",
+    "close_hour":"22:00",
+    "working_days":"segunda à sexta",
+    "address":"Rua Olivas 12",
+    "images":["https://lorempixel.com/400/400/sports/", 
+              "https://lorempixel.com/400/400/sports/"
+    ]
+  }
+]


### PR DESCRIPTION
Consumo de API externa para trazer informação de academias disponíveis e colocá-las na home do site.

Utilizei `Faraday` para fazer o request, o código foi baseado no exemplo do @HenriqueMorato postado no resumo da semana no canal do slack.

Também utilizei a lib `webmock` como sugerido, mas confesso que o código não ficou muito claro para mim e teria dificuldade de explicar para o grupo o que eu fiz xD... segui os exemplos desse [video](https://youtu.be/Okck4Fc557o)

O meu código também quebrou vários teste, porque sempre que o teste passava pelo `root_path` era feita um requisição para API de academias. Então crie uma função no `rails_helper` e chamei nos teste que estavam quebrando com a função `before(:each)` do `Rspec` que roda a função `stub_get_json` para cada cenário